### PR TITLE
_skippedPagesReported was placed wrong

### DIFF
--- a/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/PdfModule.java
+++ b/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/PdfModule.java
@@ -2916,8 +2916,8 @@ public class PdfModule extends ModuleBase {
 				if (!_skippedPagesReported) {
 					info.setMessage(
 							new InfoMessage(MessageConstants.PDF_HUL_112)); // PDF-HUL-112
+                                        _skippedPagesReported = true;
 				}
-				_skippedPagesReported = true;
 			}
 		} catch (PdfException e) {
 


### PR DESCRIPTION
Hi @carl, 

This pull request places the _skippedPagesReported inside the if statement as all other _skipped* variables.

Sam