### PR TITLE
fixes #924 by adding the invalid flag a newly added Exception

### DIFF
--- a/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/PdfModule.java
+++ b/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/PdfModule.java
@@ -3502,6 +3502,7 @@ public class PdfModule extends ModuleBase {
                         JhoveMessages.getMessageInstance(
                                 e.getJhoveMessage().getId(), e.getJhoveMessage().getMessage(),
                                 e.getJhoveMessage().getSubMessage())));
+                info.setValid(false);
             }
         } catch (Exception e) {
 


### PR DESCRIPTION
This commit fixes a bug where I forgot to set the invalid flag after a newly added Exception.